### PR TITLE
Reduce beaker-pe to a development dependendency

### DIFF
--- a/beaker-rspec.gemspec
+++ b/beaker-rspec.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'thin'
 
   # Dependency for example spec/acceptance tests
-  s.add_runtime_dependency 'beaker-pe'
+  s.add_development_dependency 'beaker-pe'
 
   # Run time dependencies
   s.add_runtime_dependency 'beaker', '> 3.0'


### PR DESCRIPTION
In 776f6961725843fce98f6f6b0f18f0926c8a3527 beaker-pe was added as a runtime dependency, but it is really only needed in the spec/ directory.

Fixes: 776f6961725843fce98f6f6b0f18f0926c8a3527