### PR TITLE
(maint) Update specs RS_SETFILE to use rocky instead of centos

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,3 @@
-ENV['RS_SETFILE'] ||= 'centos8-64'
+ENV['RS_SETFILE'] ||= 'redhat8-64'
 
 require "beaker-rspec"


### PR DESCRIPTION
Internally, we have no centos8 vms and this is blocking beaker-pe pipelines that attempt to run beaker-rspec for compatibility. Switching to rocky8 instead.