### PR TITLE
Allow to disable debug output

### DIFF
--- a/lib/beaker-rspec/spec_helper.rb
+++ b/lib/beaker-rspec/spec_helper.rb
@@ -41,7 +41,7 @@ RSpec.configure do |c|
   nodesetfile = options[:nodesetfile] || File.join(nodesetdir, "#{options[:nodeset]}.yml")
   fresh_nodes = options[:provision] == 'no' ? '--no-provision' : nil
   keyfile = options[:keyfile] ? ['--keyfile', options[:keyfile]] : nil
-  debug = options[:debug] ? ['--log-level', 'debug'] : nil
+  debug = options[:debug] && options[:debug] != 'no' ? ['--log-level', 'debug'] : nil
   color = options[:color] == 'no' ? ['--no-color'] : nil
   options_file = options[:optionsfile] ? ['--options-file',options[:optionsfile]] : nil
 


### PR DESCRIPTION
Currently if `BEAKER_debug` variable is set to anything then `beaker` is started with `--log-level debug` CLI option. This change allows to not enable debug logging if `BEAKER_debug` is set to `no`. That's useful when some upper layer sets this variable by default (as there is no way to unset it after).